### PR TITLE
Fix many memory issues found with valgrind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lxc"
 version = "0.3.0"
-authors = ["Sanpi <sanpi@homecomputing.fr>"]
-repository = "https://github.com/sanpii/lxc-rs.git"
+authors = ["Sanpi <sanpi@homecomputing.fr>", "Evgenii Lepikhin <e.lepikhin@corp.mail.ru>" ]
+repository = "https://github.com/johnlepikhin/lxc-rs.git"
 documentation = "https://docs.rs/lxc"
 keywords = ["lxc"]
 license = "MIT"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,36 +1,25 @@
 use std::os::raw::c_char;
 
-pub fn to_cstr(s: &str) -> *const c_char {
-    let buffer = std::ffi::CString::new(s).unwrap();
-    let ptr = buffer.as_ptr();
-
-    std::mem::forget(buffer);
-
-    ptr
+pub fn to_cstr(s: &str) -> *mut c_char {
+    std::ffi::CString::new(s).unwrap().into_raw()
 }
 
-pub fn to_mut_cstr(s: &str) -> *mut c_char {
-    let mut bytes = s.to_string().into_bytes();
-    bytes.push(0);
-
-    let mut c_chars: Vec<c_char> = bytes.iter().map(|b| *b as c_char).collect();
-
-    std::mem::forget(bytes);
-
-    c_chars.as_mut_ptr()
-}
-
-pub fn to_nullable_cstr(s: Option<&str>) -> *const c_char {
+pub fn to_nullable_cstr(s: Option<&str>) -> *mut c_char {
     if s.is_none() {
-        return std::ptr::null();
+        return std::ptr::null_mut();
     }
 
-    let buffer = std::ffi::CString::new(s.unwrap()).unwrap();
-    let ptr = buffer.as_ptr();
+    std::ffi::CString::new(s.unwrap()).unwrap().into_raw()
+}
 
-    std::mem::forget(buffer);
-
-    ptr
+pub fn release(p: *mut c_char) {
+    if p.is_null() {
+        std::mem::forget(p);
+    } else {
+        unsafe {
+            let _ = std::ffi::CString::from_raw(p);
+        }
+    }
 }
 
 pub fn to_string(s: *const c_char) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-}
+impl std::error::Error for Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -35,9 +34,7 @@ pub type Result<T> = std::result::Result<T, Error>;
  * Determine version of LXC.
  */
 pub fn version() -> String {
-    let version = unsafe {
-        std::ffi::CStr::from_ptr(lxc_sys::lxc_get_version())
-    };
+    let version = unsafe { std::ffi::CStr::from_ptr(lxc_sys::lxc_get_version()) };
 
     version.to_str().unwrap().to_string()
 }
@@ -46,16 +43,12 @@ pub fn version() -> String {
  * Obtain a list of all container states.
  */
 pub fn wait_states() -> Vec<String> {
-    let size = unsafe {
-        lxc_sys::lxc_get_wait_states(std::ptr::null_mut())
-    };
+    let size = unsafe { lxc_sys::lxc_get_wait_states(std::ptr::null_mut()) };
 
     let mut states = Vec::new();
     states.resize(size as usize, std::ptr::null());
 
-    unsafe {
-        lxc_sys::lxc_get_wait_states(states.as_mut_ptr())
-    };
+    unsafe { lxc_sys::lxc_get_wait_states(states.as_mut_ptr()) };
 
     states.iter().map(|e| self::ffi::to_string(*e)).collect()
 }
@@ -64,9 +57,9 @@ pub fn wait_states() -> Vec<String> {
  * Get the value for a global config key.
  */
 pub fn get_global_config_item(key: &str) -> Option<String> {
-    let value = unsafe {
-        lxc_sys::lxc_get_global_config_item(self::ffi::to_cstr(key))
-    };
+    let c_key = self::ffi::to_cstr(key);
+    let value = unsafe { lxc_sys::lxc_get_global_config_item(c_key) };
+    self::ffi::release(c_key);
 
     if value.is_null() {
         None
@@ -80,9 +73,10 @@ pub fn get_global_config_item(key: &str) -> Option<String> {
  */
 #[cfg(feature = "v2_1")]
 pub fn config_item_is_supported(key: &str) -> bool {
-    unsafe {
-        lxc_sys::lxc_config_item_is_supported(self::ffi::to_cstr(key))
-    }
+    let c_key = self::ffi::to_cstr(key);
+    let r = unsafe { lxc_sys::lxc_config_item_is_supported(c_key) };
+    self::ffi::release(c_key);
+    r
 }
 
 pub fn list_active_containers() {


### PR DESCRIPTION
Using Valgrind I found many memory related issues and tried to fix them all. The main idea is to explicitly release CStrings only after they been used by liblxc.

Also code was reformatted with rustfmt.