### PR TITLE
FIX: unfreeze method

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -199,7 +199,7 @@ impl Container {
      * Thaw a frozen container.
      */
     pub fn unfreeze(&self) -> crate::Result {
-        call!(self.freeze() -> bool)
+        call!(self.unfreeze() -> bool)
     }
 
     /**


### PR DESCRIPTION
Changed:

    /**
     * Thaw a frozen container.
     */
    pub fn unfreeze(&self) -> crate::Result {
        call!(self.freeze() -> bool)
    }

To:
    /**
     * Thaw a frozen container.
     */
    pub fn unfreeze(&self) -> crate::Result {
        call!(self.unfreeze() -> bool)
    }

I plan to implement some unimplemented methods in the close future. This pull request is just to set things up.